### PR TITLE
Load MLflow config from YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ highpeaks-ml-platform/
     ```
     Installs required libraries (Flask, ML tools, data processing libraries, etc.).
 
-3. **Run the Flask service locally:**
+3. **Configure MLflow settings:**
+    Edit `config/settings.yaml` to set the `tracking_uri` and `model_uri` under the `mlflow` section.
+    You can also point the application at a different configuration file by setting the `SERVICE_CONFIG_PATH` environment variable.
+
+4. **Run the Flask service locally:**
     ```bash
     python app.py
     ```
@@ -61,7 +65,7 @@ highpeaks-ml-platform/
     ```
     You should receive a JSON response indicating a sample prediction.
 
-4. **Build and run Docker container:**
+5. **Build and run Docker container:**
     ```bash
     docker build -t highpeaks-ml-platform:latest .
     docker run -p 5000:5000 highpeaks-ml-platform:latest

--- a/app.py
+++ b/app.py
@@ -1,10 +1,19 @@
+import os
 from flask import Flask, jsonify
+import yaml
+import mlflow
 import mlflow.pyfunc
 import numpy as np
 
 app = Flask(__name__)
 
-MODEL_URI = "models:/mnist-model/latest"
+config_path = os.environ.get("SERVICE_CONFIG_PATH", "config/settings.yaml")
+with open(config_path, "r") as f:
+    config = yaml.safe_load(f)
+
+mlflow.set_tracking_uri(config["mlflow"]["tracking_uri"])
+
+MODEL_URI = config["mlflow"].get("model_uri", "models:/mnist-model/latest")
 model = mlflow.pyfunc.load_model(MODEL_URI)
 
 @app.route('/predict', methods=['GET'])

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -25,3 +25,4 @@ data:
 mlflow:
   tracking_uri: http://localhost:5001
   experiment_name: default
+  model_uri: models:/mnist-model/latest


### PR DESCRIPTION
## Summary
- load configuration from YAML and set MLflow tracking URI
- allow overriding config path with `SERVICE_CONFIG_PATH`
- document the new configuration behavior

## Testing
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pytest -q` *(fails: command not found)*