### PR TITLE
Enable test suites

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,32 +1,27 @@
-"""Tests for the prediction endpoint are commented out.
+"""Tests for the prediction endpoint."""
 
-They require network access to download an MLflow model and depend on
-packages that are not available in the execution environment (e.g.
-``numpy`` and ``mlflow``). To enable these tests, configure the
-container with network access and install the required dependencies as
-listed in ``requirements.txt``.
-"""
+import numpy as np
+import pytest
+import mlflow.pyfunc
 
-# import numpy as np
-# import pytest
-# import mlflow.pyfunc
-#
-#
-# class DummyModel:
-#     def predict(self, data):
-#         return np.array([[0.0, 1.0]])
-#
-#
-# mlflow.pyfunc.load_model = lambda uri: DummyModel()
-#
-# from app import app
-#
-# @pytest.fixture
-# def client():
-#     app.testing = True
-#     return app.test_client()
-#
-# def test_predict_endpoint(client):
-#     response = client.get('/predict')
-#     assert response.status_code == 200
-#     assert 'predicted_class' in response.get_json()
+
+class DummyModel:
+    def predict(self, data):
+        return np.array([[0.0, 1.0]])
+
+
+mlflow.pyfunc.load_model = lambda uri: DummyModel()
+
+from app import app  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    app.testing = True
+    return app.test_client()
+
+
+def test_predict_endpoint(client):
+    response = client.get('/predict')
+    assert response.status_code == 200
+    assert 'predicted_class' in response.get_json()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,22 +1,18 @@
-"""Configuration file tests are disabled.
+"""Tests for configuration files."""
 
-These tests require the ``pyyaml`` package, which is unavailable in the
-current execution environment. To enable them, install dependencies from
-``requirements.txt`` and provide the container with network access.
-"""
+import yaml
+from pathlib import Path
 
-# import yaml
-# from pathlib import Path
-#
-#
-# def test_settings_yaml_has_required_keys():
-#     settings_path = Path(__file__).resolve().parents[1] / "config" / "settings.yaml"
-#     with open(settings_path, 'r') as f:
-#         data = yaml.safe_load(f)
-#
-#     assert "service" in data
-#     assert "data" in data
-#     assert "mlflow" in data
-#     # check nested keys
-#     assert "name" in data["service"]
-#     assert "tracking_uri" in data["mlflow"]
+
+def test_settings_yaml_has_required_keys():
+    config_dir = Path(__file__).resolve().parents[1] / "config"
+    settings_path = config_dir / "settings.yaml"
+    with open(settings_path, 'r') as f:
+        data = yaml.safe_load(f)
+
+    assert "service" in data
+    assert "data" in data
+    assert "mlflow" in data
+    # check nested keys
+    assert "name" in data["service"]
+    assert "tracking_uri" in data["mlflow"]

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -1,59 +1,70 @@
-"""Data pipeline tests are disabled.
+"""Tests for the data pipeline scripts."""
 
-These tests rely on ``numpy`` and network access to download datasets.
-Neither is available in the current execution environment. To enable
-them, provide the container with network access and install the required
-dependencies from ``requirements.txt``.
-"""
+import os
+import runpy
+import numpy as np
+import requests
+from pathlib import Path
 
-# import os
-# import runpy
-# import numpy as np
-# import requests
-# from pathlib import Path
-#
-#
-# def test_sample_ingestion_pipeline_downloads_file(tmp_path, monkeypatch):
-#     def fake_get(url):
-#         class Resp:
-#             status_code = 200
-#             content = b'dummy'
-#
-#             def raise_for_status(self):
-#                 pass
-#         return Resp()
-#
-#     monkeypatch.setattr(requests, "get", fake_get)
-#     script_path = Path(__file__).resolve().parents[1] / "data" / "ingestion" / "sample_ingestion_pipeline.py"
-#     cwd = os.getcwd()
-#     os.chdir(tmp_path)
-#     try:
-#         runpy.run_path(script_path, run_name="__main__")
-#     finally:
-#         os.chdir(cwd)
-#
-#     expected = tmp_path / "data" / "raw" / "mnist.npz"
-#     assert expected.exists()
-#
-#
-# def test_process_mnist_outputs_file(tmp_path):
-#     script_path = Path(__file__).resolve().parents[1] / "data" / "processing" / "process_mnist.py"
-#
-#     raw_dir = tmp_path / "data" / "raw"
-#     raw_dir.mkdir(parents=True)
-#
-#     x_train = np.zeros((1, 28, 28), dtype=np.uint8)
-#     y_train = np.array([0], dtype=np.uint8)
-#     x_test = np.zeros((1, 28, 28), dtype=np.uint8)
-#     y_test = np.array([0], dtype=np.uint8)
-#     np.savez(raw_dir / "mnist.npz", x_train=x_train, y_train=y_train, x_test=x_test, y_test=y_test)
-#
-#     cwd = os.getcwd()
-#     os.chdir(tmp_path)
-#     try:
-#         runpy.run_path(script_path, run_name="__main__")
-#     finally:
-#         os.chdir(cwd)
-#
-#     expected = tmp_path / "data" / "processed" / "mnist_processed.npz"
-#     assert expected.exists()
+
+def test_sample_ingestion_pipeline_downloads_file(tmp_path, monkeypatch):
+    def fake_get(url):
+        class Resp:
+            status_code = 200
+            content = b'dummy'
+
+            def raise_for_status(self):
+                pass
+
+        return Resp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "ingestion"
+        / "sample_ingestion_pipeline.py"
+    )
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        runpy.run_path(script_path, run_name="__main__")
+    finally:
+        os.chdir(cwd)
+
+    expected = tmp_path / "data" / "raw" / "mnist.npz"
+    assert expected.exists()
+
+
+def test_process_mnist_outputs_file(tmp_path):
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "processing"
+        / "process_mnist.py"
+    )
+
+    raw_dir = tmp_path / "data" / "raw"
+    raw_dir.mkdir(parents=True)
+
+    x_train = np.zeros((1, 28, 28), dtype=np.uint8)
+    y_train = np.array([0], dtype=np.uint8)
+    x_test = np.zeros((1, 28, 28), dtype=np.uint8)
+    y_test = np.array([0], dtype=np.uint8)
+    np.savez(
+        raw_dir / "mnist.npz",
+        x_train=x_train,
+        y_train=y_train,
+        x_test=x_test,
+        y_test=y_test,
+    )
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        runpy.run_path(script_path, run_name="__main__")
+    finally:
+        os.chdir(cwd)
+
+    expected = tmp_path / "data" / "processed" / "mnist_processed.npz"
+    assert expected.exists()


### PR DESCRIPTION
## Summary
- uncomment and enable tests
- add flake8 ignore for delayed import
- format long paths for flake8 compliance

## Testing
- `flake8 app.py tests/test_app.py tests/test_config.py tests/test_data_pipeline.py`
- `pytest -q`