### PR TITLE
Fix deploy script cluster config

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -104,6 +104,10 @@ k8s_deploy() {
       --config infrastructure/k8s/kind-cluster.yaml
   fi
 
+  # ensure kubeconfig is set for the current user
+  echo "🔧 Exporting kubeconfig..."
+  kind export kubeconfig --name highpeaks-ml
+
   # force Kind to use /tmp as its scratch space
   unset TMPDIR
   


### PR DESCRIPTION
## Summary
- make sure kubeconfig is exported before applying manifests

## Testing
- `pytest -q`
- `flake8 app.py`
- `python scripts/validate_k8s_manifests.py infrastructure/k8s/`
