### PR TITLE
Fix kubernetes deploy script and port names

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -122,7 +122,11 @@ k8s_deploy() {
   rm highpeaks-ml-platform.tar
 
   echo "📑 Applying Kubernetes manifests..."
-  kubectl apply -f infrastructure/k8s/
+  kubectl apply -f infrastructure/k8s/namespace.yaml
+  kubectl apply -f infrastructure/k8s/storage.yaml
+  kubectl apply -f infrastructure/k8s/deployment.yaml
+  kubectl apply -f infrastructure/k8s/service.yaml
+  kubectl apply -f infrastructure/k8s/mlflow.yaml
   echo "✅ Kubernetes deployment complete"
 }
 

--- a/infrastructure/k8s/storage.yaml
+++ b/infrastructure/k8s/storage.yaml
@@ -44,9 +44,11 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 9000
+    - name: api
+      port: 9000
       targetPort: 9000
-    - port: 9001
+    - name: console
+      port: 9001
       targetPort: 9001
   selector:
     app: minio


### PR DESCRIPTION
## Summary
- skip applying the kind cluster manifest and apply YAMLs in order
- add required port names to MinIO service

## Testing
- `flake8 app.py`
- `pytest -q`
- `./deploy.sh k8s` *(fails: could not install docker via apt due to network)*