### PR TITLE
Fix deploy script low disk usage

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -152,23 +152,11 @@ k8s_deploy() {
   unset TMPDIR
   
   echo "📥 Loading image into kind..."
-  echo "🧹 Cleaning up old tarballs and Docker temp…"
-  TMPDIR="${DEPLOY_TMPDIR:-/tmp}"
-  rm -f "$TMPDIR/highpeaks-ml-platform.tar"
-  rm -f "$TMPDIR/.docker_temp_*" 2>/dev/null || true
-
-  echo "📂 Using temporary directory $TMPDIR"
-  echo "📥 Saving image to tarball ($TMPDIR/highpeaks-ml-platform.tar)…"
-  IMG_SIZE=$(docker image inspect highpeaks-ml-platform:latest --format='{{.Size}}')
-  
-  ensure_space "$TMPDIR" "$IMG_SIZE" || { disk_usage_report; exit 1; }
-  docker save highpeaks-ml-platform:latest -o "$TMPDIR/highpeaks-ml-platform.tar" || { disk_usage_report; exit 1; }
-
-  echo "📥 Loading image into kind from tarball…"
-  kind load image-archive "$TMPDIR/highpeaks-ml-platform.tar" --name highpeaks-ml
-
-  echo "🧹 Removing temporary tar…"
-  rm "$TMPDIR/highpeaks-ml-platform.tar"
+  if ! kind load docker-image highpeaks-ml-platform:latest --name highpeaks-ml; then
+    echo "❌ Failed to load Docker image into kind" >&2
+    disk_usage_report
+    exit 1
+  fi
 
   echo "📑 Applying Kubernetes manifests..."
   kubectl apply -f infrastructure/k8s/namespace.yaml


### PR DESCRIPTION
## Summary
- load Docker image directly into kind without a tarball

## Testing
- `flake8 app.py`
- `pytest -q`
- `python scripts/validate_k8s_manifests.py infrastructure/k8s/`
- `docker build -t highpeaks-ml-platform-ci:build .` *(fails: `docker: command not found`)*