### PR TITLE
Fix kind image loading with tmpdir

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -128,6 +128,10 @@ local_deploy() {
 }
 
 k8s_deploy() {
+  TMPDIR=$(mktemp -d)
+  export TMPDIR
+  trap 'rm -rf "$TMPDIR"' EXIT
+
   install_docker
   install_kubectl
   install_kind
@@ -148,14 +152,17 @@ k8s_deploy() {
   echo "🔧 Exporting kubeconfig..."
   kind export kubeconfig --name highpeaks-ml
 
-  # force Kind to use /tmp as its scratch space
-  unset TMPDIR
-  
   echo "📥 Loading image into kind..."
   if ! kind load docker-image highpeaks-ml-platform:latest --name highpeaks-ml; then
-    echo "❌ Failed to load Docker image into kind" >&2
-    disk_usage_report
-    exit 1
+    echo "⚠️ kind load failed, attempting docker save fallback..." >&2
+    if docker save highpeaks-ml-platform:latest -o "$TMPDIR/images.tar" && \
+       kind load image-archive "$TMPDIR/images.tar" --name highpeaks-ml; then
+      echo "✔️ Image loaded via docker save fallback"
+    else
+      echo "❌ Failed to load Docker image into kind" >&2
+      disk_usage_report
+      exit 1
+    fi
   fi
 
   echo "📑 Applying Kubernetes manifests..."


### PR DESCRIPTION
## Summary
- use a temporary directory for kind image loading in `deploy.sh`
- fallback to `docker save` if `kind load` fails
- quote trap command correctly

## Testing
- `python3 -m flake8 app.py`
- `pytest -q`
